### PR TITLE
fix: respect entity_type param and map purpose→type for context mints

### DIFF
--- a/src/agents/validator.js
+++ b/src/agents/validator.js
@@ -81,8 +81,8 @@ export class ValidatorAgent {
       return { valid: false, reason: "Invalid sequential ID" };
     }
 
-    // Type: valid entity types (single letters)
-    const validTypes = ["P", "L", "T", "E"];
+    // @canon: chittycanon://gov/governance#core-types
+    const validTypes = ["P", "L", "T", "E", "A"];
     if (!validTypes.includes(type)) {
       return { valid: false, reason: "Invalid entity type" };
     }

--- a/src/api/index.js
+++ b/src/api/index.js
@@ -65,7 +65,8 @@ export class ChittyAPI {
         method: 'GET',
         handler: async (request, url) => {
           const purpose = url.searchParams.get('for') || 'general';
-          return await this.pipeline.process(request, purpose);
+          const entityTypeOverride = url.searchParams.get('entity_type') || null;
+          return await this.pipeline.process(request, purpose, entityTypeOverride);
         }
       },
 
@@ -244,7 +245,8 @@ export class ChittyAPI {
             'P': 'Person',
             'L': 'Location',
             'T': 'Thing',
-            'E': 'Event'
+            'E': 'Event',
+            'A': 'Authority'
           }
         },
         YM: {

--- a/src/config/index.js
+++ b/src/config/index.js
@@ -75,11 +75,13 @@ export const ChittyConfig = {
       '8': 'International Waters',
       '9': 'Digital/Virtual'
     },
+    // @canon: chittycanon://gov/governance#core-types
     entityTypes: {
       'P': 'Person',
       'L': 'Location',
       'T': 'Thing',
-      'E': 'Event'
+      'E': 'Event',
+      'A': 'Authority'
     },
     trustLevels: {
       '0': 'L0 - Unverified',

--- a/src/pipeline/index.js
+++ b/src/pipeline/index.js
@@ -21,10 +21,11 @@ export class ChittyPipeline {
    * @param {string} purpose - Purpose of ID request (e.g., 'work-item', 'document')
    * @returns {Promise<PipelineResult>}
    */
-  async process(request, purpose = "general") {
+  async process(request, purpose = "general", entityTypeOverride = null) {
     const context = {
       request,
       purpose,
+      entityTypeOverride,
       timestamp: new Date().toISOString(),
       stages: {},
     };
@@ -306,10 +307,16 @@ class GenerationStage {
 
     try {
       // Prepare parameters for id.chitty.cc service
+      // Explicit entity_type override takes precedence over purpose-based mapping
+      const validEntityTypes = ["P", "L", "T", "E", "A"];
+      const override = context.entityTypeOverride;
+      const entityType = (override && validEntityTypes.includes(override.toUpperCase()))
+        ? override.toUpperCase()
+        : this.mapPurposeToEntityType(purpose);
       const params = {
         region: this.determineRegion(user),
         jurisdiction: this.determineJurisdiction(user),
-        entityType: this.mapPurposeToEntityType(purpose),
+        entityType,
         trustLevel: trustLevel.toString(),
         metadata: {
           userId: user.id,
@@ -399,12 +406,16 @@ class GenerationStage {
     return jurisdictionMap[user.country] || "INT";
   }
 
+  // @canon: chittycanon://gov/governance#core-types
   mapPurposeToEntityType(purpose) {
     const mapping = {
       person: "P",
       location: "L",
       thing: "T",
       event: "E",
+      authority: "A",
+      context: "P",    // Contexts are Person (P, Synthetic) — actors with agency
+      agent: "P",      // Agents are Person (P, Synthetic) — actors with agency
       "work-item": "T",
       document: "T",
       asset: "T",

--- a/src/services/vrf-generator.js
+++ b/src/services/vrf-generator.js
@@ -188,8 +188,9 @@ export class VRFGenerator {
       throw new Error("Namespace must be exactly 3 letters");
     }
 
-    if (!["P", "L", "T", "E"].includes(entityType)) {
-      throw new Error("Entity type must be P, L, T, or E");
+    // @canon: chittycanon://gov/governance#core-types
+    if (!["P", "L", "T", "E", "A"].includes(entityType)) {
+      throw new Error("Entity type must be P, L, T, E, or A");
     }
 
     if (!region || region < "1" || region > "9") {

--- a/worker.js
+++ b/worker.js
@@ -111,11 +111,17 @@ function getErrorFromId(chittyId) {
   };
 }
 
+// Purpose-to-entity-type mapping for non-type values passed via ?for=
+// @canon: chittycanon://gov/governance#core-types
+const PURPOSE_ENTITY_MAP = { context: 'person', claude: 'person', 'work-item': 'thing', document: 'thing', general: 'thing' };
+
 // Direct ChittyID generation handler - delegates to ChittyMint with fallback
 async function handleDirectChittyIdGeneration(url, env, request) {
-  const rawType = (url.searchParams.get('type') || url.searchParams.get('for') || 'thing').toLowerCase();
-  // Accept both code-form (P/L/T/E/A) and word-form (person/place/thing/event/authority)
-  const entityTypeParam = CODE_TO_WORD[rawType] || rawType;
+  // Priority: explicit entity_type > type > for (with purpose mapping) > default 'thing'
+  const explicitType = url.searchParams.get('entity_type');
+  const rawType = (explicitType || url.searchParams.get('type') || url.searchParams.get('for') || 'thing').toLowerCase();
+  // Accept code-form (P/L/T/E/A), word-form (person/place/thing/event/authority), or purpose (context/claude)
+  const entityTypeParam = CODE_TO_WORD[rawType] || PURPOSE_ENTITY_MAP[rawType] || rawType;
 
   // Extract auth token if present (forward to ChittyMint)
   const authHeader = request?.headers?.get('Authorization');


### PR DESCRIPTION
## Summary
- `entity_type` query param was ignored — only `type` and `for` were read
- `for=context` mapped to raw "context" which had no entry in `ENTITY_TYPES`, defaulting to `T` (Thing)
- Now: `entity_type` is highest priority, and a `PURPOSE_ENTITY_MAP` resolves purpose values like `context`→`person` (P)

## Root cause
```js
// Before: only reads type/for, "context" falls through to default T
const rawType = (url.searchParams.get('type') || url.searchParams.get('for') || 'thing')
```

## Test plan
- [ ] `GET /api/get-chittyid?for=context` returns entity type `P`
- [ ] `GET /api/get-chittyid?entity_type=P` returns entity type `P`
- [ ] `GET /api/get-chittyid?for=thing` still returns `T`
- [ ] `GET /api/get-chittyid?type=person` still returns `P`
- [ ] Deploy to id.chitty.cc and verify with `can chitty authenticate-context`

## Related
- chittyos/chittycan#49 — client-side workaround until this is deployed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for a new "Authority" entity type to the system's supported types.
  * Entity type can now be explicitly overridden during ID generation, providing greater flexibility in type assignment.
  * Expanded recognition of additional purpose categories to improve entity type mapping.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->