### PR TITLE
feat(mint): canonical /mint + 308-redirect deprecated aliases (E1)

### DIFF
--- a/worker.js
+++ b/worker.js
@@ -464,19 +464,37 @@ export default {
         });
       }
 
-      // Generate endpoint - delegates to ChittyMint
-      if (url.pathname === "/generate" && request.method === "GET") {
+      // E1 canonical mint endpoint: POST /mint (short, logical, id.chitty.cc as primary)
+      if (url.pathname === "/mint" && request.method === "POST") {
         return await handleDirectChittyIdGeneration(url, env, request);
       }
 
-      // VRF mint endpoint - delegates to ChittyMint
+      // E1 deprecated aliases — 308 to canonical /mint with deprecation headers.
+      // 308 preserves method+body. Includes Deprecation, Sunset, Link, Warning headers
+      // so clients see migration hint regardless of how they handle redirects.
+      const deprecationHeaders = {
+        "Location": "https://id.chitty.cc/mint",
+        "Deprecation": "true",
+        "Sunset": "2027-05-27",
+        "Link": "<https://id.chitty.cc/mint>; rel=\"successor-version\", <chittycanon://gov/sops/012-chittyid-format>; rel=\"deprecation\"",
+        "Warning": "299 - \"Deprecated endpoint. POST https://id.chitty.cc/mint is the canonical mint route. Sunset 2027-05-27.\"",
+        "Access-Control-Allow-Origin": "*"
+      };
+
       if (url.pathname === "/v1/mint" && request.method === "POST") {
-        return await handleDirectChittyIdGeneration(url, env, request);
+        return new Response(JSON.stringify({
+          _deprecation: { canonical: "https://id.chitty.cc/mint", sunset: "2027-05-27", note: "POST /v1/mint is deprecated. Use POST /mint." }
+        }), { status: 308, headers: deprecationHeaders });
       }
-
-      // Direct API handlers (bypassing Pages Functions import issues)
       if (url.pathname === "/api/get-chittyid" && request.method === "GET") {
-        return await handleDirectChittyIdGeneration(url, env, request);
+        return new Response(JSON.stringify({
+          _deprecation: { canonical: "https://id.chitty.cc/mint", sunset: "2027-05-27", note: "GET /api/get-chittyid is deprecated. POST https://id.chitty.cc/mint with {entityType:\"P\"} body." }
+        }), { status: 308, headers: deprecationHeaders });
+      }
+      if (url.pathname === "/generate" && request.method === "GET") {
+        return new Response(JSON.stringify({
+          _deprecation: { canonical: "https://id.chitty.cc/mint", sunset: "2027-05-27", note: "GET /generate is deprecated. POST https://id.chitty.cc/mint with {entityType:\"P\"} body." }
+        }), { status: 308, headers: deprecationHeaders });
       }
 
       if (url.pathname === "/api/health" && request.method === "GET") {


### PR DESCRIPTION
POST /mint is now the canonical endpoint. /v1/mint, /api/get-chittyid, /generate return 308 to /mint with deprecation reminder headers + JSON body. Sunset 2027-05-27.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Changes**
  * Standardized the mint endpoint to a single canonical route.
  * Legacy mint endpoints now return deprecation notices and direct users to the current endpoint.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/chittyfoundation/chittyid/pull/19?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->