### PR TITLE
refactor(naming): drop legacy 'mothership' label

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -38,7 +38,7 @@ jobs:
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-          projectName: chittyid-mothership
+          projectName: chittyid
           directory: dist
           gitHubToken: ${{ secrets.GITHUB_TOKEN }}
           deployment-trigger: ${{ github.event_name }}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project Overview
 
-This is the **ChittyID Mothership** - a Cloudflare Worker-based management system for ChittyIDs from the id.chitty.cc service. ChittyID is a universal identity system for people, places, things, and events, implemented as part of the broader ChittyOS ecosystem.
+This is the **ChittyID** - a Cloudflare Worker-based management system for ChittyIDs from the id.chitty.cc service. ChittyID is a universal identity system for people, places, things, and events, implemented as part of the broader ChittyOS ecosystem.
 
 ### Key Architecture Components
 

--- a/_worker.js
+++ b/_worker.js
@@ -35,7 +35,7 @@ export default {
           return new Response(`<!DOCTYPE html>
 <html>
 <head>
-    <title>ChittyID Mothership</title>
+    <title>ChittyID</title>
     <meta charset="utf-8">
     <style>
         body { font-family: Arial, sans-serif; margin: 40px; background: #f5f5f5; }
@@ -48,7 +48,7 @@ export default {
 </head>
 <body>
     <div class="container">
-        <h1>🚀 ChittyID Mothership</h1>
+        <h1>🚀 ChittyID</h1>
         <div class="status">
             <strong>Status:</strong> AI Agent System Active<br>
             <strong>Version:</strong> 1.0.0<br>

--- a/canon/api-routes-chittyid.js
+++ b/canon/api-routes-chittyid.js
@@ -410,7 +410,7 @@ async function handleGetChittyId(request, env, circuitBreaker, api) {
         headers: {
           ...corsHeaders(),
           "X-Pipeline-Completed": "true",
-          "X-ChittyOS-Service": "chittyid-mothership",
+          "X-ChittyOS-Service": "chittyid",
         },
       },
     );
@@ -501,7 +501,7 @@ export async function onRequest(context) {
       const html = `<!DOCTYPE html>
 <html>
 <head>
-    <title>ChittyID Mothership</title>
+    <title>ChittyID</title>
     <meta charset="utf-8">
     <style>
         body { font-family: Arial, sans-serif; margin: 40px; background: #f5f5f5; }
@@ -514,7 +514,7 @@ export async function onRequest(context) {
 </head>
 <body>
     <div class="container">
-        <h1>🚀 ChittyID Mothership</h1>
+        <h1>🚀 ChittyID</h1>
         <div class="status">
             <strong>Status:</strong> AI Agent System Active<br>
             <strong>Version:</strong> 2.0.0<br>

--- a/canon/worker-chittyid.js
+++ b/canon/worker-chittyid.js
@@ -1,5 +1,5 @@
 /**
- * ChittyID Mothership - Cloudflare Worker Entry Point
+ * ChittyID - Cloudflare Worker Entry Point
  * Hardened Security Configuration with Pipeline Enforcement
  * Enhanced with MCP Portal Integration and LangChain AI Routing
  */
@@ -215,7 +215,7 @@ export default {
             "Content-Type": "application/json",
             "X-Security-Error": "true",
             "X-Pipeline-Required": "true",
-            "X-ChittyOS-Service": "chittyid-mothership",
+            "X-ChittyOS-Service": "chittyid",
             "X-MCP-Portal": "enabled",
             "X-LangChain-AI": "integrated",
           },

--- a/chitty-cli.ts
+++ b/chitty-cli.ts
@@ -229,7 +229,7 @@ async function validate(id: string): Promise<void> {
 
     if (!res.ok) {
       // Fallback to worker validation
-      const workerRes = await fetch(`https://chittyid-mothership.chitty.workers.dev/api/validate`, {
+      const workerRes = await fetch(`https://chittyid.chitty.workers.dev/api/validate`, {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json'

--- a/dashboard.html
+++ b/dashboard.html
@@ -280,7 +280,7 @@
                     {/* Footer */}
                     <div className="text-xs text-gray-600 flex items-center gap-3">
                         <Save /> Auto-saves to localStorage. Drag headers to move. Resize from corners.
-                        <span className="ml-auto">ChittyID Mothership • id.chitty.cc • Powered by ChittyRouter AI Gateway</span>
+                        <span className="ml-auto">ChittyID • id.chitty.cc • Powered by ChittyRouter AI Gateway</span>
                     </div>
                 </div>
             );

--- a/functions/api/[[route]].js
+++ b/functions/api/[[route]].js
@@ -417,7 +417,7 @@ async function handleGetChittyId(request, env, circuitBreaker, api) {
         headers: {
           ...corsHeaders(),
           "X-Pipeline-Completed": "true",
-          "X-ChittyOS-Service": "chittyid-mothership",
+          "X-ChittyOS-Service": "chittyid",
         },
       },
     );
@@ -632,7 +632,7 @@ export async function onRequest(context) {
       const html = `<!DOCTYPE html>
 <html>
 <head>
-    <title>ChittyID Mothership</title>
+    <title>ChittyID</title>
     <meta charset="utf-8">
     <style>
         body { font-family: Arial, sans-serif; margin: 40px; background: #f5f5f5; }
@@ -645,7 +645,7 @@ export async function onRequest(context) {
 </head>
 <body>
     <div class="container">
-        <h1>🚀 ChittyID Mothership</h1>
+        <h1>🚀 ChittyID</h1>
         <div class="status">
             <strong>Status:</strong> AI Agent System Active<br>
             <strong>Version:</strong> 2.0.0<br>

--- a/manifest.json
+++ b/manifest.json
@@ -98,7 +98,7 @@
   },
   "metadata": {
     "chittyos": {
-      "service": "chittyid-mothership",
+      "service": "chittyid",
       "enforcement_level": "MAXIMUM",
       "pipeline_required": true,
       "bypassable": false

--- a/monitoring/dashboards/grafana-chittyid.json
+++ b/monitoring/dashboards/grafana-chittyid.json
@@ -1,7 +1,7 @@
 {
   "dashboard": {
     "id": null,
-    "title": "ChittyID Mothership - Production Dashboard",
+    "title": "ChittyID - Production Dashboard",
     "tags": ["chittyos", "identity", "production"],
     "timezone": "UTC",
     "refresh": "30s",

--- a/monitoring/metrics/prometheus.yml
+++ b/monitoring/metrics/prometheus.yml
@@ -13,8 +13,8 @@ alerting:
           - alertmanager:9093
 
 scrape_configs:
-  # ChittyID Mothership - Main Service
-  - job_name: 'chittyid-mothership'
+  # ChittyID - Main Service
+  - job_name: 'chittyid'
     static_configs:
       - targets: ['id.chitty.cc:443']
     scheme: https

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -11,7 +11,7 @@ PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 BUILD_DIR="$PROJECT_ROOT/dist"
 LOG_FILE="$PROJECT_ROOT/deployment.log"
 CLOUDFLARE_ACCOUNT_ID="${CLOUDFLARE_ACCOUNT_ID:-84f0f32886f1d6196380fe6cbe9656a8}"
-PROJECT_NAME="chittyid-mothership"
+PROJECT_NAME="chittyid"
 
 # Colors for output
 RED='\033[0;31m'
@@ -169,7 +169,7 @@ deploy_worker() {
 
     # Deploy worker
     log "Deploying worker..."
-    if ! wrangler deploy --name chittyid-mothership; then
+    if ! wrangler deploy --name chittyid; then
         error "Worker deployment failed"
     fi
 
@@ -184,7 +184,7 @@ deploy_pages() {
 
     # Deploy to Pages
     log "Deploying to Pages..."
-    if ! wrangler pages deploy dist --project-name=chittyid-mothership --compatibility-date=2025-01-16; then
+    if ! wrangler pages deploy dist --project-name=chittyid --compatibility-date=2025-01-16; then
         error "Pages deployment failed"
     fi
 
@@ -232,7 +232,7 @@ setup_monitoring() {
     # Create basic monitoring configuration
     cat > "$PROJECT_ROOT/monitoring-config.json" << EOF
 {
-  "service": "chittyid-mothership",
+  "service": "chittyid",
   "version": "2.0.0",
   "endpoints": {
     "health": "/api/health",
@@ -358,7 +358,7 @@ generate_report() {
 ## Rollback Plan
 
 If issues arise:
-1. \`wrangler rollback chittyid-mothership\` - Rollback worker
+1. \`wrangler rollback chittyid\` - Rollback worker
 2. \`git revert <commit>\` - Revert code changes
 3. Deploy previous version with \`npm run deploy\`
 

--- a/scripts/monitor-notion-sync.js
+++ b/scripts/monitor-notion-sync.js
@@ -5,7 +5,7 @@
  * Monitors sync health and alerts on failures
  */
 
-const WORKER_URL = process.env.NOTION_SYNC_WORKER_URL || 'https://notion-sync.chittyid-mothership.workers.dev';
+const WORKER_URL = process.env.NOTION_SYNC_WORKER_URL || 'https://notion-sync.chittyid.workers.dev';
 const ALERT_THRESHOLD = {
     schema_mismatch: 0,
     rate_limit_percentage: 2,

--- a/scripts/setup-env.sh
+++ b/scripts/setup-env.sh
@@ -193,7 +193,7 @@ create_wrangler_config() {
         warn "wrangler.toml not found. Creating basic configuration..."
 
         cat > wrangler.toml << 'EOF'
-name = "chittyid-mothership"
+name = "chittyid"
 compatibility_date = "2025-01-16"
 pages_build_output_dir = "dist"
 
@@ -270,7 +270,7 @@ create_monitoring_config() {
 {
   "dashboard": {
     "id": null,
-    "title": "ChittyID Mothership",
+    "title": "ChittyID",
     "tags": ["chittyos", "identity"],
     "timezone": "browser",
     "panels": [

--- a/src/api/index.js
+++ b/src/api/index.js
@@ -159,7 +159,7 @@ export class ChittyAPI {
         method: 'GET',
         handler: async () => {
           return {
-            name: 'ChittyID Mothership API',
+            name: 'ChittyID API',
             version: '2.0.0',
             description: 'ChittyID management system for IDs from id.chitty.cc',
             endpoints: {

--- a/src/components/ChittyDashboard.jsx
+++ b/src/components/ChittyDashboard.jsx
@@ -225,7 +225,7 @@ export default function ChittyDashboard() {
       {/* Footer */}
       <div className="text-xs text-black/60 flex items-center gap-3">
         <Save className="h-4 w-4" /> Layout auto-saves to localStorage. Drag to reorder. Resize corners. Import/Export JSON to version.
-        <span className="ml-auto">ChittyID Mothership • id.chitty.cc • Powered by ChittyRouter AI Gateway</span>
+        <span className="ml-auto">ChittyID • id.chitty.cc • Powered by ChittyRouter AI Gateway</span>
       </div>
     </div>
   );

--- a/src/config/index.js
+++ b/src/config/index.js
@@ -7,7 +7,7 @@ export const ChittyConfig = {
   // API Configuration
   api: {
     version: '2.0.0',
-    name: 'ChittyID Mothership',
+    name: 'ChittyID',
     description: 'Identity management system for ChittyIDs from id.chitty.cc service',
     baseUrl: 'https://id.chitty.cc',
     timeout: 30000, // 30 seconds

--- a/src/middleware/pipeline-enforcer.js
+++ b/src/middleware/pipeline-enforcer.js
@@ -124,7 +124,7 @@ export class PipelineEnforcer {
           headers: {
             'Content-Type': 'application/json',
             'X-Pipeline-Required': 'true',
-            'X-ChittyOS-Service': 'chittyid-mothership'
+            'X-ChittyOS-Service': 'chittyid'
           }
         }
       );
@@ -347,7 +347,7 @@ export class PipelineEnforcer {
           'Content-Type': 'application/json',
           'X-Pipeline-Required': 'true',
           'X-Pipeline-Enforcement': 'MANDATORY',
-          'X-ChittyOS-Service': 'chittyid-mothership',
+          'X-ChittyOS-Service': 'chittyid',
           'Access-Control-Allow-Origin': '*',
           'Access-Control-Expose-Headers': 'X-Pipeline-Required,X-Pipeline-Enforcement'
         }
@@ -361,7 +361,7 @@ export class PipelineEnforcer {
   addEnforcementHeaders(response) {
     const headers = new Headers(response.headers);
     headers.set('X-Pipeline-Enforcement', 'ACTIVE');
-    headers.set('X-ChittyOS-Service', 'chittyid-mothership');
+    headers.set('X-ChittyOS-Service', 'chittyid');
     headers.set('X-Pipeline-Info', 'Generation requires pipeline completion');
 
     return new Response(response.body, {
@@ -379,7 +379,7 @@ export class PipelineEnforcer {
     headers.set('X-Pipeline-Completed', 'true');
     headers.set('X-Pipeline-Stages', pipelineContext.stages.join(','));
     headers.set('X-Pipeline-Trust-Level', pipelineContext.trustLevel.toString());
-    headers.set('X-ChittyOS-Service', 'chittyid-mothership');
+    headers.set('X-ChittyOS-Service', 'chittyid');
 
     return new Response(response.body, {
       status: response.status,

--- a/src/middleware/request-interceptor.js
+++ b/src/middleware/request-interceptor.js
@@ -656,7 +656,7 @@ export class RequestInterceptor {
           "X-Security-Block": "true",
           "X-Block-Reason": reason,
           "X-Pipeline-Required": "true",
-          "X-ChittyOS-Service": "chittyid-mothership",
+          "X-ChittyOS-Service": "chittyid",
         },
       },
     );

--- a/src/services/registry-client.js
+++ b/src/services/registry-client.js
@@ -19,11 +19,11 @@ export class RegistryClient {
    */
   buildServiceInfo() {
     return {
-      service: 'chittyid-mothership',
-      name: 'ChittyID Mothership',
+      service: 'chittyid',
+      name: 'ChittyID',
       version: '2.0.0',
       description: 'Identity management system with hardened security pipeline',
-      endpoint: 'https://chittyid-mothership.chitty.workers.dev',
+      endpoint: 'https://chittyid.chitty.workers.dev',
       domain: 'https://id.chitty.cc',
       health: '/api/health',
       priority: 1,
@@ -50,7 +50,7 @@ export class RegistryClient {
         ]
       },
       registeredAt: new Date().toISOString(),
-      registeredBy: 'chittyid-mothership-deployment'
+      registeredBy: 'chittyid-deployment'
     };
   }
 
@@ -104,7 +104,7 @@ export class RegistryClient {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
-        'X-ChittyOS-Service': 'chittyid-mothership',
+        'X-ChittyOS-Service': 'chittyid',
         'X-ChittyOS-Version': '2.0.0'
       },
       body: JSON.stringify(this.serviceInfo)
@@ -166,7 +166,7 @@ export class RegistryClient {
             method: 'PUT',
             headers: {
               'Content-Type': 'application/json',
-              'X-ChittyOS-Service': 'chittyid-mothership'
+              'X-ChittyOS-Service': 'chittyid'
             },
             body: JSON.stringify({
               status,
@@ -198,7 +198,7 @@ export class RegistryClient {
    */
   async getHealthStatus() {
     try {
-      const response = await fetch('https://chittyid-mothership.chitty.workers.dev/api/health');
+      const response = await fetch('https://chittyid.chitty.workers.dev/api/health');
       if (response.ok) {
         return await response.json();
       }
@@ -239,7 +239,7 @@ export class RegistryClient {
           const response = await fetch(`${registration.registry}/api/services/${registration.registrationId}`, {
             method: 'DELETE',
             headers: {
-              'X-ChittyOS-Service': 'chittyid-mothership'
+              'X-ChittyOS-Service': 'chittyid'
             }
           });
 

--- a/src/services/topic-sync.js
+++ b/src/services/topic-sync.js
@@ -102,7 +102,7 @@ export class TopicSync {
         },
 
         metadata: {
-          createdBy: "chittyid-mothership",
+          createdBy: "chittyid",
           version: "1.0.0",
           embedding: null,
           keywords: [],
@@ -262,7 +262,7 @@ export class TopicSync {
       sender: {
         type: message.senderType || "user",
         id: message.senderId,
-        service: message.service || "chittyid-mothership",
+        service: message.service || "chittyid",
       },
       content: {
         text: message.text,

--- a/src/workers/notion-sync-worker.js
+++ b/src/workers/notion-sync-worker.js
@@ -484,7 +484,7 @@ export class NotionSyncWorker {
                     this.metrics.upsert_skipped,
                     this.metrics.dlq_pushed
                 ],
-                indexes: ['chittyid-mothership']
+                indexes: ['chittyid']
             });
         }
     }

--- a/test-advanced.sh
+++ b/test-advanced.sh
@@ -4,7 +4,7 @@ echo "🔐 ADVANCED SECURITY TESTING"
 echo "============================"
 echo ""
 
-ENDPOINT="https://chittyid-mothership.chitty.workers.dev"
+ENDPOINT="https://chittyid.chitty.workers.dev"
 
 # Test Rate Limiting
 echo "⚡ Testing Rate Limiting..."

--- a/test-security.sh
+++ b/test-security.sh
@@ -4,7 +4,7 @@ echo "🔒 COMPREHENSIVE SECURITY TEST BATTERY"
 echo "======================================"
 echo ""
 
-ENDPOINT="https://chittyid-mothership.chitty.workers.dev"
+ENDPOINT="https://chittyid.chitty.workers.dev"
 
 # Test 1: Legacy Endpoints
 echo "1️⃣  Testing Legacy Endpoint Blocking..."

--- a/tests/qa/pipeline-enforcement.test.js
+++ b/tests/qa/pipeline-enforcement.test.js
@@ -423,7 +423,7 @@ describe('Pipeline Enforcement QA Tests', () => {
 
       expect(result.headers.get('X-Pipeline-Required')).toBe('true');
       expect(result.headers.get('X-Pipeline-Enforcement')).toBe('MANDATORY');
-      expect(result.headers.get('X-ChittyOS-Service')).toBe('chittyid-mothership');
+      expect(result.headers.get('X-ChittyOS-Service')).toBe('chittyid');
     });
   });
 

--- a/worker.js
+++ b/worker.js
@@ -1,5 +1,5 @@
 /**
- * ChittyID Mothership - Cloudflare Worker Entry Point
+ * ChittyID - Cloudflare Worker Entry Point
  * Hardened Security Configuration with Pipeline Enforcement
  * Enhanced with MCP Portal Integration and LangChain AI Routing
  */
@@ -456,7 +456,7 @@ export default {
       if (url.pathname === "/health" && request.method === "GET") {
         return new Response(JSON.stringify({
           status: "ok",
-          service: "chittyid-mothership",
+          service: "chittyid",
           version: "2.0.0",
           timestamp: new Date().toISOString()
         }), {
@@ -502,7 +502,7 @@ export default {
           status: "healthy",
           version: "2.0.0",
           timestamp: new Date().toISOString(),
-          service: "chittyid-mothership"
+          service: "chittyid"
         }), {
           headers: { "Content-Type": "application/json", "Access-Control-Allow-Origin": "*" }
         });
@@ -601,7 +601,7 @@ export default {
         error: "NOT_FOUND",
         message: `Route not found: ${url.pathname}`,
         timestamp: new Date().toISOString(),
-        service: "chittyid-mothership"
+        service: "chittyid"
       }), {
         status: 404,
         headers: { "Content-Type": "application/json", "Access-Control-Allow-Origin": "*" }
@@ -630,7 +630,7 @@ export default {
             "Content-Type": "application/json",
             "X-Security-Error": "true",
             "X-Pipeline-Required": "true",
-            "X-ChittyOS-Service": "chittyid-mothership",
+            "X-ChittyOS-Service": "chittyid",
             "X-MCP-Portal": "enabled",
             "X-LangChain-AI": "integrated",
           },

--- a/wrangler-pages.toml
+++ b/wrangler-pages.toml
@@ -1,4 +1,4 @@
-name = "chittyid-mothership"
+name = "chittyid"
 compatibility_date = "2025-01-16"
 pages_build_output_dir = "dist"
 


### PR DESCRIPTION
## Summary
- Replace `chittyid-mothership` with `chittyid` and `ChittyID Mothership` with `ChittyID` across 27 live files (code, prose, config, monitoring, scripts).
- Aligns this repo with the worker name in `wrangler.jsonc` and the canonical `Chitty<Word>` service-naming rule.
- Follow-up sweep after PR #20.

## Breaking change (minor)
- `/health` response and `X-ChittyOS-Service` header now return `chittyid` instead of `chittyid-mothership`.
- Downstream scan: one doc-only reference in `CHITTYOS/chittyops/spec/daily-updates-orchestration-v0.5.md:172`. No runtime matcher found.

## Scope
- Excluded archived dirs and `*.bak` / `*.original` files.

## Test plan
- [x] `node --check` on touched JS / function modules
- [x] JSON parse on package.json, manifest.json, grafana dashboard
- [x] grep mothership returns zero hits in live files

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Service rebranding: ChittyID Mothership is now called ChittyID
  * Updated all deployment configurations, worker names, endpoint URLs, and service identifiers
  * Refreshed service headers and registration metadata throughout the platform

* **Documentation**
  * Updated production dashboard title and monitoring configurations to reflect new name
  * Refreshed UI branding in application footer and documentation pages

<!-- end of auto-generated comment: release notes by coderabbit.ai -->