### PR TITLE
fix(urls): repair workers.dev URLs broken by mothership rename

### DIFF
--- a/scripts/monitor-notion-sync.js
+++ b/scripts/monitor-notion-sync.js
@@ -5,7 +5,13 @@
  * Monitors sync health and alerts on failures
  */
 
-const WORKER_URL = process.env.NOTION_SYNC_WORKER_URL || 'https://notion-sync.chittyid.workers.dev';
+const WORKER_URL = process.env.NOTION_SYNC_WORKER_URL;
+if (!WORKER_URL) {
+    console.error('ERROR: NOTION_SYNC_WORKER_URL is not set.');
+    console.error('Set it to the deployed notion-sync worker URL, e.g.:');
+    console.error('  export NOTION_SYNC_WORKER_URL=https://notion-sync.chitty.cc');
+    process.exit(1);
+}
 const ALERT_THRESHOLD = {
     schema_mismatch: 0,
     rate_limit_percentage: 2,

--- a/src/services/registry-client.js
+++ b/src/services/registry-client.js
@@ -18,12 +18,16 @@ export class RegistryClient {
    * Build service information for registration
    */
   buildServiceInfo() {
+    const publicUrl =
+      this.env?.CHITTYID_SERVICE_URL ||
+      this.env?.SERVICE_PUBLIC_URL ||
+      'https://id.chitty.cc';
     return {
       service: 'chittyid',
       name: 'ChittyID',
       version: '2.0.0',
       description: 'Identity management system with hardened security pipeline',
-      endpoint: 'https://chittyid.chitty.workers.dev',
+      endpoint: publicUrl,
       domain: 'https://id.chitty.cc',
       health: '/api/health',
       priority: 1,


### PR DESCRIPTION
## Summary
Follow-up to #21. Addresses two Codex review comments where the mothership->chittyid rename mechanically replaced `chittyid-mothership` with `chittyid` inside workers.dev URLs, breaking URL structure semantics (the renamed segment was the *account subdomain*, not the worker name). Compounded by `workers_dev: false` in `wrangler.jsonc`, meaning these URLs never resolved either before or after the rename.

- `src/services/registry-client.js:26`: registered endpoint now reads from `env.CHITTYID_SERVICE_URL` (matches the convention in `src/client/index.js`) or `SERVICE_PUBLIC_URL`, falling back to canonical route `https://id.chitty.cc`. No hardcoded workers.dev URL.
- `scripts/monitor-notion-sync.js:8`: `NOTION_SYNC_WORKER_URL` is now required; the script fails fast with a clear error if unset. No wrangler config in this repo deploys `src/workers/notion-sync-worker.js`, so picking any canonical URL would be guessing.

## Notes
- `src/workers/notion-sync-worker.js` may be dead code: no `wrangler.toml`/`wrangler.jsonc` deploys it. Worth a separate cleanup PR if confirmed.

## Test plan
- [x] `node --check src/services/registry-client.js`
- [x] `node --check scripts/monitor-notion-sync.js`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated service configuration to require explicit environment variables for worker and service endpoint URLs. Hardcoded defaults have been replaced with configurable environment-based settings to support flexible deployment configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->