### PR TITLE
fix(cli): restore Authority (A) and canonical segment widths in ChittyID patterns

### DIFF
--- a/chitty-cli.ts
+++ b/chitty-cli.ts
@@ -48,13 +48,23 @@ const headers = {
  */
 const CHITTYID_PATTERNS = {
   // Canonical structured format: VV-G-LLL-SSSS-T-YYMM-C-XX
-  structured: /^[A-Z0-9]{2}-\d-[A-Z]{3}-\d{4}-[PLTE]-\d{2,4}-\d-\d{2}$/,
+  // @canon: chittycanon://gov/governance#core-types
+  // T is the full P/L/T/E/A set — omitting A (Authority) rejects every
+  // Authority-type ID. Segment 6 is YYMM (exactly 4); segments 7 and 8 are
+  // alphanumeric, matching both live-minted and documented IDs.
+  // LLL is alphanumeric: live IDs use 'USA', the documented example uses '001'.
+  structured: /^[A-Z0-9]{2}-[A-Z0-9]-[A-Z0-9]{3}-\d{4}-[PLTEA]-\d{4}-[A-Z0-9]-[A-Z0-9]{2}$/,
 
   // Legacy UUID format: chitty_<uuid>
   uuid: /^chitty_[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i,
 
   // Extended format for compatibility
-  extended: /^[A-Z0-9]{2}-[A-Z0-9]-[A-Z0-9]{3}-[A-Z0-9]{4}-[A-Z0-9]-[A-Z0-9]{4}-[A-Z0-9]-[A-Z0-9]$/
+  // Segment 8 is XX (two chars), not one — a single-char class rejects every
+  // real ID and made `extended` dead weight behind `structured`.
+  // "Compatibility" relaxes segment *shape*, never the entity-type set:
+  // isChittyId() ORs these patterns, so a permissive T here would let a
+  // non-canonical entity type pass the whole check.
+  extended: /^[A-Z0-9]{2}-[A-Z0-9]-[A-Z0-9]{3}-[A-Z0-9]{4}-[PLTEA]-[A-Z0-9]{4}-[A-Z0-9]-[A-Z0-9]{2}$/
 };
 
 /**


### PR DESCRIPTION
## Problem

The service that **owns** the ChittyID format shipped CLI validators that violate it.

`chitty-cli.ts` `CHITTYID_PATTERNS.structured` used `[PLTE]` — silently dropping **A (Authority)**, one of the five core types (`chittycanon://gov/governance#core-types`). Every Authority-type ChittyID failed validation in the format's own repo.

`extended` required a 1-char segment 8, so it matched no real ID at all. Worse: it left the type segment fully open, and because `isChittyId()` **ORs** the patterns, that let a non-canonical entity type pass the entire check.

## Evidence

Tested against live-minted IDs from `registry.chitty.cc/api/v1/tools`:

| Pattern | Before | After |
|---|---|---|
| `structured` | rejects all `A`-type IDs; `\d{2,4}` YYMM; digit-only seg8 | accepts `P/L/T/E/A`, `YYMM`, alphanumeric seg 7–8 |
| `extended` | matched **no** real ID; accepted entity type `X` | matches real IDs; enforces `[PLTEA]` |

This repo's own `CHARTER.md:81`, `README.md:26`, and `CLAUDE.md:22` all specify `VV-G-LLL-SSSS-T-YYMM-C-XX` — the docs were already right; only the code disagreed.

`LLL` is alphanumeric to cover both live `USA` and the documented `001` (`CP-A-001-1234-P-2509-I-82`).

## Not in scope

`src/hybrid/master-entity-schema.js` and `src/hybrid/id-translation-worker.js` describe a **different** legacy "legal ID" whose own example (`01-N-USA-1234-P-25-3-X`) contradicts its own pattern. Neither is reachable from `worker.js` (`id-translation-worker.js` is referenced by nothing). Changing that layer's semantics needs its own decision rather than a drive-by edit.

## Validation

Patterns parsed **out of the edited file** and run against 5 real/documented IDs and 5 malformed inputs: all real accepted, all malformed rejected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DHwB8WGY7wkS3kQMGC8pTL